### PR TITLE
Chroma colors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -273,6 +273,24 @@ export default function Home() {
     }
   };
 
+  // Define colorblind-friendly color sets for different vision modes
+  const getColorScheme = (mode: VisionMode) => {
+    // Each array contains colors for [green, red, yellow] in order
+    switch(mode) {
+      case 'protanomaly': // Red-weak, enhance distinction between red and green
+        return ['#00DDDD', '#FFAAAA', '#EEEE00'];
+      case 'deuteranomaly': // Green-weak, enhance distinction
+        return ['#0088FF', '#FF5555', '#EEEE00'];
+      case 'tritanomaly': // Blue-yellow weakness
+        return ['#00DD88', '#FF4444', '#FFFFFF'];
+      case 'achromatopsia': // No color perception (monochromacy)
+        return ['#FFFFFF', '#666666', '#BBBBBB'];
+      case 'normal':
+      default:
+        return ['green', 'red', 'yellow'];
+    }
+  };
+
   // Create canvas overlay for bounding boxes
   const createOverlayImage = (data: DetectionItem[]) => {
     if (!data || data.length === 0) {
@@ -289,6 +307,10 @@ export default function Home() {
     ctx.clearRect(0, 0, width, height);
     const widthCoef = width / 640;
     const heightCoef = height / 640;
+    
+    // Get appropriate color scheme based on current vision mode
+    const colors = getColorScheme(visionMode);
+    
     data.forEach(item => {
       if (Array.isArray(item) && item.length === 6) {
         const x1 = item[0] * widthCoef;
@@ -296,7 +318,6 @@ export default function Home() {
         const x2 = item[2] * widthCoef;
         const y2 = item[3] * heightCoef;
         const label = item[5];
-        const colors = ['green', 'red', 'yellow'];
         ctx.strokeStyle = colors[Math.floor(label)] || 'white';
         ctx.lineWidth = 3;
         ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
@@ -430,6 +451,7 @@ export default function Home() {
           onToggleAI={toggleAI}
           serverStatus={serverStatus}
           serverAddress={serverAddress}
+          visionMode={visionMode}
         />
       </div>
     </div>

--- a/src/components/CameraView.tsx
+++ b/src/components/CameraView.tsx
@@ -18,12 +18,12 @@ interface CameraViewProps {
 }
 
 const CameraView: React.FC<CameraViewProps> = ({
-                                                 isActive,
-                                                 onImageCapture,
-                                                 socket,
-                                                 onResult,
-                                                 serverStatus = 'disconnected'
-                                               }) => {
+  isActive,
+  onImageCapture,
+  socket,
+  onResult,
+  serverStatus = 'disconnected'
+}) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/components/ResultPanel.tsx
+++ b/src/components/ResultPanel.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+type VisionMode = 'normal' | 'protanomaly' | 'deuteranomaly' | 'tritanomaly' | 'achromatopsia';
+
 interface ResultPanelProps {
   label?: string;
   confidence?: number;
@@ -7,6 +9,7 @@ interface ResultPanelProps {
   onToggleAI?: () => void;
   serverStatus?: 'connected' | 'disconnected' | 'checking' | 'error';
   serverAddress?: string;
+  visionMode?: VisionMode;
 }
 
 const ResultPanel: React.FC<ResultPanelProps> = ({ 
@@ -15,12 +18,13 @@ const ResultPanel: React.FC<ResultPanelProps> = ({
   isAiActive = false,
   onToggleAI,
   serverStatus = 'disconnected',
-  serverAddress = ''
+  serverAddress = '',
+  visionMode = 'normal'
 }) => {
   // Format confidence as percentage
   const formattedConfidence = `${Math.round(confidence * 100)}%`;
   
-  // Get background color based on label or status
+  // Get background color based on label, status, and vision mode
   const getBackgroundColor = () => {
     if (!isAiActive) return 'bg-black';
     
@@ -28,10 +32,42 @@ const ResultPanel: React.FC<ResultPanelProps> = ({
       return 'bg-red-900';
     }
     
+    // Base colors for normal vision
+    let greenClass = 'bg-green-700';
+    let redClass = 'bg-red-700';
+    let yellowClass = 'bg-yellow-600';
+    
+    // Adjust colors for different vision modes
+    switch (visionMode) {
+      case 'protanomaly': // Red-weak
+        greenClass = 'bg-cyan-600'; // More blue in green
+        redClass = 'bg-rose-400'; // Lighter, more visible red
+        yellowClass = 'bg-yellow-400'; // Brighter yellow
+        break;
+      case 'deuteranomaly': // Green-weak
+        greenClass = 'bg-blue-600'; // More blue than green
+        redClass = 'bg-red-600'; // Standard red
+        yellowClass = 'bg-yellow-400'; // Brighter yellow
+        break;
+      case 'tritanomaly': // Blue-yellow weakness
+        greenClass = 'bg-emerald-500'; // Clearer green
+        redClass = 'bg-red-600'; // Standard red
+        yellowClass = 'bg-white'; // White instead of yellow
+        break;
+      case 'achromatopsia': // No color vision
+        greenClass = 'bg-white'; // White
+        redClass = 'bg-gray-600'; // Dark gray
+        yellowClass = 'bg-gray-300'; // Light gray
+        break;
+      default:
+        // Use standard colors
+        break;
+    }
+    
     switch (label) {
-      case 'Зелёный': return 'bg-green-700';
-      case 'Красный': return 'bg-red-700';
-      case 'Жёлтый': return 'bg-yellow-600';
+      case 'Зелёный': return greenClass;
+      case 'Красный': return redClass;
+      case 'Жёлтый': return yellowClass;
       default: return 'bg-black';
     }
   };


### PR DESCRIPTION
This pull request introduces a new feature to support colorblind-friendly color schemes in the application. The changes include defining color sets for different vision modes and updating the components to use these color schemes.

### Vision Mode Support:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR276-R293): Added a function `getColorScheme` to define color sets for different vision modes and updated the canvas overlay creation to use the appropriate color scheme based on the current vision mode. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR276-R293) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR310-L299)
* [`src/components/ResultPanel.tsx`](diffhunk://#diff-d0aa9d245966de9fa9c22eaf3e68925b563a7dbf16e60b7565e4b7d87f8305a6R3-R12): Added a new type `VisionMode` and updated the `ResultPanel` component to accept a `visionMode` prop. Adjusted the background colors based on the vision mode to enhance accessibility for colorblind users. [[1]](diffhunk://#diff-d0aa9d245966de9fa9c22eaf3e68925b563a7dbf16e60b7565e4b7d87f8305a6R3-R12) [[2]](diffhunk://#diff-d0aa9d245966de9fa9c22eaf3e68925b563a7dbf16e60b7565e4b7d87f8305a6L18-R70)

### Propagation of Vision Mode:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR454): Passed the `visionMode` prop to the `ResultPanel` component to ensure the selected vision mode is used throughout the application.